### PR TITLE
fix: lower the minimum `eth-utils` version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -960,4 +960,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "60ebe638e3a178e99b46b1653d1b6f66bf3fb6e1b3d5ec2dd2c491c332866d03"
+content-hash = "b57c81569b585652509dbb3932e746f0758c45e2efd64c145b38c4305d02fe44"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ python = "^3.8"
 
 # 3rd party
 eth-abi = "^5.1.0"
-eth-utils = "^4.0.0"
+eth-utils = ">=2.0.0"
 pycryptodome = "^3.17.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Trying to upgrade to `web3-input-decoder` v0.1.12 and getting this kind of error from `pip`:

```
The conflict is caused by:
    web3 6.20.2 depends on eth-utils<5 and >=2.1.0
    web3-input-decoder 0.1.12 depends on eth-utils<5.0.0 and >=4.0.0
    eth-tester 0.10.0b1 depends on eth-utils>=2.0.0
    eth-tester[py-evm] 0.10.0b1 depends on eth-utils>=2.0.0
    py-evm 0.7.0a4 depends on eth-utils<3.0.0 and >=2.0.0
```

As you see, `web3-input-decoder` is the one asking for a higher `eth-utils` version.

Would it be OK for you to lower that requirement?